### PR TITLE
fix tokenized sentence problem

### DIFF
--- a/bert_base/bert/tokenization.py
+++ b/bert_base/bert/tokenization.py
@@ -132,6 +132,9 @@ class FullTokenizer(object):
   def convert_ids_to_tokens(self, ids):
     return convert_by_vocab(self.inv_vocab, ids)
 
+  def mark_unk_tokens(self, tokens, unk_token='[UNK]'):
+    return [t if t in self.vocab else unk_token for t in tokens]
+
 
 class BasicTokenizer(object):
   """Runs basic tokenization (punctuation splitting, lower casing, etc.)."""

--- a/bert_base/bert/tokenization.py
+++ b/bert_base/bert/tokenization.py
@@ -87,8 +87,8 @@ def convert_by_vocab(vocab, items):
   output = []
   for item in items:
     #TODO: modify for oov, using [unk] replace, if you using english language do not change this
-    # output.append(vocab.[item])
-    output.append(vocab.get(item, 100))
+    output.append(vocab[item])
+    # output.append(vocab.get(item, 100))
   return output
 
 


### PR DESCRIPTION
If BertClient.encode is to be called with is_tokenized parameter set to True, There will be an exception because the client didn't find the mark_unk_tokens function. I added it from the original ber_base to fix this problem. Also, I am not sure the point of "vocab.get(item, 100)", because unknown tokens have already been taken care of. And I haven't encountered any problem changing it back to vocab[item], do let me know if you have any problem with the first commit.