### PR TITLE
remove print func here due to UnicodeEncodeError

### DIFF
--- a/bert_base/server/http.py
+++ b/bert_base/server/http.py
@@ -45,7 +45,6 @@ class BertHTTPProxy(Process):
             data = request.form if request.form else request.json
             try:
                 logger.info('new request from %s' % request.remote_addr)
-                print(data)
                 return {'id': data['id'],
                         'result': bc.encode(data['texts'], is_tokenized=bool(
                             data['is_tokenized']) if 'is_tokenized' in data else False)}


### PR DESCRIPTION
When I am using the trained NER model as service via http port, I found if the input json is something like 
query_json = {
    "id": 100,
    "texts": ["Beijing"]
},
everything is right. However, if the input json is something like 
query_json = {
    "id": 100,
    "texts": ["北京"]
},
then it raises Exception as below:
UnicodeEncodeError: 'ascii' codec can't encode characters in position 23-25: ordinal not in range(128)
I found this error comes from this print func and I think it should be removed here. In hanxiao's Bert-as-service, it does not contain this line (https://github.com/hanxiao/bert-as-service/blob/91bff1c2d0403e1afa9ee1af9dd9cb0dd58fe0d3/server/bert_serving/server/http.py#L57) and it supports Chinese well.
So I suggest removing this print func here.