### PR TITLE
add try/finally to ConcurrentBertClient avoid not release BertClient …

### DIFF
--- a/bert_base/client/__init__.py
+++ b/bert_base/client/__init__.py
@@ -427,9 +427,11 @@ class ConcurrentBertClient(BertClient):
         def arg_wrapper(self, *args, **kwargs):
             try:
                 bc = self.available_bc.pop()
-                f = getattr(bc, func.__name__)
-                r = f if isinstance(f, dict) else f(*args, **kwargs)
-                self.available_bc.append(bc)
+                try:
+                    f = getattr(bc, func.__name__)
+                    r = f if isinstance(f, dict) else f(*args, **kwargs)
+                finally:
+                    self.available_bc.append(bc)
                 return r
             except IndexError:
                 raise RuntimeError('Too many concurrent connections!'


### PR DESCRIPTION
add try/finally to ConcurrentBertClient avoid not release BertClient on exception
in my case, if pass contents contains space will cause BertClient not released and end up with error message 

>  Too many concurrent connections!Try to increase the value of "max_concurrency"